### PR TITLE
README update; struct cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,70 @@
-# mirrorbot
-A slack bot that will go and query the various OCP mirrors and give you the latest mirror information directly to you
+# MirrorBot
+
+A Slack bot for querying OpenShift release status and details.
+
+## Prerequisites
+
+- Go 1.24+ (for local development)
+- Docker (for containerized runs)
+- [Slack App](https://api.slack.com/apps) with:
+  - Bot Token (`SLACK_BOT_TOKEN`)
+  - App Token (`SLACK_APP_TOKEN`) with Socket Mode enabled
+- (Optional) [golangci-lint](https://golangci-lint.run/usage/install/) for linting
+
+## How to Run
+
+### 1. Clone the repository
+
+```bash
+git clone https://github.com/sebrandon1/mirrorbot.git
+cd mirrorbot
+```
+
+### 2. Set up your Slack tokens
+
+Export your Slack tokens as environment variables:
+
+```bash
+export SLACK_BOT_TOKEN='xoxb-...'
+export SLACK_APP_TOKEN='xapp-...'
+```
+
+### 3. Run locally (with Go)
+
+```bash
+make build
+./mirrorbot
+```
+
+### 4. Run in Docker
+
+Build and run the image:
+
+```bash
+make docker-build
+make run-image
+```
+
+> **Note:** The `run-image` target checks for your Slack tokens and passes them into the container.
+
+### 5. (Optional) Lint and Test
+
+```bash
+make vet
+make lint
+make test
+```
+
+## Usage
+
+Invite the bot to a channel and mention it with an OpenShift version, e.g.:
+
+```
+@mirrorbot 4.20
+```
+
+The bot will respond with the latest release info for that version.
+
+---
+
+For more details, see the code and comments in [main.go](main.go).

--- a/pkg/ocpmirror/status.go
+++ b/pkg/ocpmirror/status.go
@@ -18,6 +18,28 @@ type ReleaseStatus struct {
 	FailedJobs        int    // total failed jobs
 }
 
+// ReleaseStatusAPIResponse represents the JSON structure returned by the OCP release status API.
+type ReleaseStatusAPIResponse struct {
+	Phase         string `json:"phase"`
+	Age           string `json:"age"`
+	ChangeLogJson struct {
+		To struct {
+			Created string `json:"created"`
+		} `json:"to"`
+		Components []struct {
+			Name    string `json:"name"`
+			Version string `json:"version"`
+			From    string `json:"from"`
+		} `json:"components"`
+	} `json:"changeLogJson"`
+	Results struct {
+		InformingJobs map[string]struct {
+			State string `json:"state"`
+		} `json:"informingJobs"`
+	} `json:"results"`
+}
+
+// ReleaseStatusDetail holds the detailed information for a release, such as the pullSpec.
 type ReleaseStatusDetail struct {
 	PullSpec string `json:"pullSpec"`
 }
@@ -32,30 +54,9 @@ func FetchReleaseStatus(version string) (*ReleaseStatus, error) {
 			continue // try next path
 		}
 		defer func() {
-			err := resp.Body.Close()
-			if err != nil {
-				fmt.Printf("Error closing response body: %v\n", err)
-			}
+			_ = resp.Body.Close()
 		}()
-		var data struct {
-			Phase         string `json:"phase"`
-			Age           string `json:"age"`
-			ChangeLogJson struct {
-				To struct {
-					Created string `json:"created"`
-				} `json:"to"`
-				Components []struct {
-					Name    string `json:"name"`
-					Version string `json:"version"`
-					From    string `json:"from"`
-				} `json:"components"`
-			} `json:"changeLogJson"`
-			Results struct {
-				InformingJobs map[string]struct {
-					State string `json:"state"`
-				} `json:"informingJobs"`
-			} `json:"results"`
-		}
+		var data ReleaseStatusAPIResponse
 		if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
 			continue // try next path
 		}


### PR DESCRIPTION
Updates the README and moves around some structs for better readability.

### Documentation Improvements:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R70): Completely rewritten with detailed sections on prerequisites, setup, running the bot (locally and in Docker), and usage examples. This makes it easier for developers to get started and understand the bot's functionality.

### Code Enhancements:
* [`pkg/ocpmirror/status.go`](diffhunk://#diff-e3b605dcde01668307631b8717494885cc4c6098e7bca67b01210f973c6d7a28L21-R22): Introduced a new `ReleaseStatusAPIResponse` struct to represent the JSON structure returned by the OpenShift release status API, improving code readability and maintainability.
* [`pkg/ocpmirror/status.go`](diffhunk://#diff-e3b605dcde01668307631b8717494885cc4c6098e7bca67b01210f973c6d7a28R41-R57): Refactored the `FetchReleaseStatus` function to use the new `ReleaseStatusAPIResponse` struct for decoding API responses, ensuring better alignment with the API's data structure.